### PR TITLE
classic: make \cvevent receive a variable number of paragaphs

### DIFF
--- a/classic/main.tex
+++ b/classic/main.tex
@@ -231,15 +231,14 @@
 %	 CV EVENT
 %----------------------------------------------------------------------------------------
 
-% creates a stretched box as cv entry headline followed by two paragraphs about 
+% creates a stretched box as cv entry headline followed by some paragraphs about 
 % the work you did
 % param 1:	event time i.e. 2014 or 2011-2014 etc.
 % param 2:	event name (what did you do?)
 % param 3:	institution (where did you work / study)
-% param 4:	what was your position
-% param 5:	some words about your contributions
+% param 4:	list of paragraphs
 %
-\newcommand{\cvevent}[5]
+\newcommand{\cvevent}[4]
 {
 
 \begin{tabular*}{1\textwidth}{p{13.6cm}  x{3.9cm}}
@@ -250,9 +249,11 @@
 \textcolor{softcol}{\hrule}
 \vspace{6pt}
 
-  $\cdot$ #4\\[3pt]
-  $\cdot$ #5\\[6pt]
-
+	\foreach \desc in {#4}{
+		$\cdot$ \desc\\[3pt]
+	}
+	
+\vspace{3pt}
 }
 
 % creates a stretched box as 
@@ -351,26 +352,41 @@ Digital media graduate with project experience in the field of technology based 
 %----------------------------------------------------------------------------------------
 \cvsection{Experience}
 
-\cvevent{2016 - present}{Scientific Employee / PhD Student}{University of Bremen}{Develop and evaluate the next generation learning management system with Meteor}{Define a new level of software for classroom management based on an extensive nursing curriculum.}
+\cvevent{2016 - present}{Scientific Employee / PhD Student}{University of Bremen}{
+	{Develop and evaluate the next generation learning management system with Meteor},
+	{Define a new level of software for classroom management based on an extensive nursing curriculum.}
+}
 
 %
-\cvevent{2014 - 2016}{IT Consultant for IBM XPages and Notes Domino}{We4IT GmbH Bremen}{Realize projects in XPages and We4IT Aveedo, monitor project status, conduct reports}{Implement the frontend for a BPMN compatible engine within We4IT Aveedo}
+\cvevent{2014 - 2016}{IT Consultant for IBM XPages and Notes Domino}{We4IT GmbH Bremen}{
+	{Realize projects in XPages and We4IT Aveedo, monitor project status, conduct reports},
+	{Implement the frontend for a BPMN compatible engine within We4IT Aveedo}
+}
 
 %\textcolor{softcol}{\hrule}
 
 %
-\cvevent{2012 - 2014}{Scientific Employee / Software Development}{University of Bremen}{Invented a flexible assessment framework, targeting industrial trainees}{Supervised software development lifecycle, Recruited team members}
+\cvevent{2012 - 2014}{Scientific Employee / Software Development}{University of Bremen}{
+	{Invented a flexible assessment framework, targeting industrial trainees},
+	{Supervised software development lifecycle, Recruited team members}
+}
 
 %\textcolor{softcol}{\hrule}
 
 %
-\cvevent{2011 / 11}{Project Management Simulation Training}{Getoq Consulting}{Performed a two-day project simulation from management perspective}{Topics included customer contracts, change management, controlling, operational tasks}
+\cvevent{2011 / 11}{Project Management Simulation Training}{Getoq Consulting}{
+	{Performed a two-day project simulation from management perspective},
+	{Topics included customer contracts, change management, controlling, operational tasks}
+}
 
 %\textcolor{softcol}{\hrule}
 
 
 %
-\cvevent{2010 - 2011}{Student Assistant / Programmer}{otulea.uni-bremen.de}{Realized an online diagnosis platform for workforce literacy development (Flex)}{Modeled software design, implemented various prototypes, conducted usability tests}
+\cvevent{2010 - 2011}{Student Assistant / Programmer}{otulea.uni-bremen.de}{
+	{Realized an online diagnosis platform for workforce literacy development (Flex)},
+	{Modeled software design, implemented various prototypes, conducted usability tests}
+}
 
 
 %---------------------------------------------------------------------------------------
@@ -378,22 +394,34 @@ Digital media graduate with project experience in the field of technology based 
 %--------------------------------------------------------------------------------------
 \cvsection{Education}
 
-\cvevent{2015 / 07}{Graduated as M.Sc. Digital Media}{University of Bremen}{Master Thesis: Semi Automated Scoring in Technology Based Assessment}{Developed and evaluated an algorithm for semi automated scoring of spreadsheet data}
+\cvevent{2015 / 07}{Graduated as M.Sc. Digital Media}{University of Bremen}{
+	{Master Thesis: Semi Automated Scoring in Technology Based Assessment},
+	{Developed and evaluated an algorithm for semi automated scoring of spreadsheet data}
+}
 
 %\textcolor{softcol}{\hrule}
 
 %
-\cvevent{2012 - 2013}{Master Project - PrIMA}{University of Bremen}{Co-Invented a touch table application for medical support, co-developed software (Java) }{Formed a scrum team, mainted project dev server (Debian), surveyed target audience}
+\cvevent{2012 - 2013}{Master Project - PrIMA}{University of Bremen}{
+	{Co-Invented a touch table application for medical support, co-developed software (Java)},
+	{Formed a scrum team, mainted project dev server (Debian), surveyed target audience}
+}
 
 %\textcolor{softcol}{\hrule}
 
 %
-\cvevent{2012 - 2015}{Master Studies Digital Media}{University of Bremen}{Inter-cultural classes in English, covering special topics in computer science and design}{Professionalized in research methods, software development and e-assessment}
+\cvevent{2012 - 2015}{Master Studies Digital Media}{University of Bremen}{
+	{Inter-cultural classes in English, covering special topics in computer science and design},
+	{Professionalized in research methods, software development and e-assessment}
+}
 
 %\textcolor{softcol}{\hrule}
 
 %
-\cvevent{2009 - 2010}{Semester Abroad}{University of Melbourne}{Mastered six months of study and trans-cultural experience in Melbourne, Australia}{Finished machine programming, information visualization, professional essay writing}
+\cvevent{2009 - 2010}{Semester Abroad}{University of Melbourne}{
+	{Mastered six months of study and trans-cultural experience in Melbourne, Australia},
+	{Finished machine programming, information visualization, professional essay writing}
+}
 
 
 %--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently it is hardcoded to have two paragraphs, while that is fine in
some situations, sometimes you might want to have a different number.
This patch changes the arguments to instead of receiving two paragraphs,
to receive a list of paragraphs.

Signed-off-by: Filipe Laíns <lains@riseup.net>