### PR TITLE
Fixed misaligned  bubble labels

### DIFF
--- a/infographics2/g/bubbles.tex
+++ b/infographics2/g/bubbles.tex
@@ -27,9 +27,9 @@
   	\filldraw[fill=thirdcol,draw=none] (#1,0.5) circle (#3);
 
   	% outer label
-  	\node[label=\textcolor{textcol}{#4}] at (#1,0.7) {};
+  	\node[label={\textcolor{textcol}{#4}\vphantom{|}}] at (#1,0.7) {};
 
-  	% outer label
+  	% inner label
   	\node[label=\textcolor{titletext}{#6}] at (#1,0.38) {};
 }
 


### PR DESCRIPTION
## Summary

This is a fix for the `\bubble{}` command used in the infographics2 template.

When the bubble command in `infographic2` is called with content that does not extrude at the bottom (like "asdf" as opposed to "qypj"), the label node is at a different height. This is due to tikz calculating node distance to the closes point of the object.


## Reproduction
To prevent misalignment due to distance calculation in tikz, add a phantom character to the non-uniform element (text). In this case a `\vphantom{|}` adds an invisible character with the height of | and no width. This should keep distances equal, even if the label is moved to the bottom of the bubble.